### PR TITLE
uwiger/edownのmasterをmerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 Copyright (c) 2014 Ulf Wiger
 
-
 __Authors:__ [`ulf@wiger.net`](mailto:ulf@wiger.net).
-
 
 Status:
 ------
@@ -63,6 +61,7 @@ The default value is `github`.
 Note that at the moment, the
 [Markdown viewer plugin](https://bitbucket.org/atlassianlabs/stash-markdown-viewer-plugin) will be needed in order to render the generated documentation
 as Markdown on Stash.
+
 Github customizations
 =====================
 `pre` tags are converted into github "fenced" code blocks, i.e.
@@ -129,7 +128,7 @@ output, since "raw" links wouldn't work for the markdown files.
 
 The next issue is that Edoc uses httpd_client to fetch the
 `edoc-info` files, which requires `inets` to be started. To
-further complicate matters, `ssl` (and thus `crypto` and
+further complicate matters, `ssl` (and thus `crypto`, 'asn1' and
 `public_key`) must also be started, since Github will
 redirect to https.
 
@@ -166,15 +165,4 @@ See [bin/MARKEDOC-README.md](http://github.com/uwiger/edown/blob/master/bin/MARK
 **FreeBSD, Mac OS X**`$ sed -E -f markedoc.sed <markdown file> > <edoc file>`
 
 **Linux**`$ sed -r -f markedoc.sed <markdown file> > <edoc file>`
-
-
-## Modules ##
-
-
-<table width="100%" border="0" summary="list of modules">
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_doclet.md" class="module">edown_doclet</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_layout.md" class="module">edown_layout</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_lib.md" class="module">edown_lib</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_make.md" class="module">edown_make</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_xmerl.md" class="module">edown_xmerl</a></td></tr></table>
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,9 +4,7 @@
 
 Copyright (c) 2014 Ulf Wiger
 
-
 __Authors:__ [`ulf@wiger.net`](mailto:ulf@wiger.net).
-
 
 Status:
 ------
@@ -63,6 +61,7 @@ The default value is `github`.
 Note that at the moment, the
 [Markdown viewer plugin](https://bitbucket.org/atlassianlabs/stash-markdown-viewer-plugin) will be needed in order to render the generated documentation
 as Markdown on Stash.
+
 Github customizations
 =====================
 `pre` tags are converted into github "fenced" code blocks, i.e.
@@ -129,7 +128,7 @@ output, since "raw" links wouldn't work for the markdown files.
 
 The next issue is that Edoc uses httpd_client to fetch the
 `edoc-info` files, which requires `inets` to be started. To
-further complicate matters, `ssl` (and thus `crypto` and
+further complicate matters, `ssl` (and thus `crypto`, 'asn1' and
 `public_key`) must also be started, since Github will
 redirect to https.
 
@@ -166,15 +165,4 @@ See [bin/MARKEDOC-README.md](bin/MARKEDOC-README.md).
 **FreeBSD, Mac OS X**`$ sed -E -f markedoc.sed <markdown file> > <edoc file>`
 
 **Linux**`$ sed -r -f markedoc.sed <markdown file> > <edoc file>`
-
-
-## Modules ##
-
-
-<table width="100%" border="0" summary="list of modules">
-<tr><td><a href="edown_doclet.md" class="module">edown_doclet</a></td></tr>
-<tr><td><a href="edown_layout.md" class="module">edown_layout</a></td></tr>
-<tr><td><a href="edown_lib.md" class="module">edown_lib</a></td></tr>
-<tr><td><a href="edown_make.md" class="module">edown_make</a></td></tr>
-<tr><td><a href="edown_xmerl.md" class="module">edown_xmerl</a></td></tr></table>
 

--- a/doc/edoc-info
+++ b/doc/edoc-info
@@ -1,4 +1,3 @@
 %% encoding: UTF-8
 {application,edown}.
-{packages,[]}.
 {modules,[edown_doclet,edown_layout,edown_lib,edown_make,edown_xmerl]}.

--- a/doc/edown_doclet.md
+++ b/doc/edown_doclet.md
@@ -5,11 +5,12 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 EDoc Doclet module for producing Markdown.
-Copyright (c) 2014 Ulf Wiger
+
+Copyright (c) 2014-2015 Ulf Wiger
 
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
 <a name="index"></a>
 
 ## Function Index ##
@@ -26,21 +27,16 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 ### run/2 ###
 
-
 <pre><code>
 run(Command::<a href="#type-doclet_gen">doclet_gen()</a> | <a href="#type-doclet_toc">doclet_toc()</a>, Ctxt::<a href="#type-edoc_context">edoc_context()</a>) -&gt; ok
 </code></pre>
 <br />
 
-
 Main doclet entry point.
-
-
 
 Also see [`//edoc/edoc:layout/2`](http://www.erlang.org/doc/man/edoc.html#layout-2) for layout-related options, and
 [`//edoc/edoc:get_doc/2`](http://www.erlang.org/doc/man/edoc.html#get_doc-2) for options related to reading source
 files.
-
 
 Options:
 

--- a/doc/edown_layout.md
+++ b/doc/edown_layout.md
@@ -5,15 +5,16 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 Markdown layout module for EDoc.
+
 Copyright (c) 2014 Ulf Wiger
 
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
 <a name="description"></a>
 
 ## Description ##
-  Derived from `edoc_layout`, which is part of the Erlang/OTP application EDoc.
+Derived from `edoc_layout`, which is part of the Erlang/OTP application EDoc.
 The module is intended to be used together with edoc.<a name="index"></a>
 
 ## Function Index ##
@@ -32,16 +33,13 @@ The module is intended to be used together with edoc.<a name="index"></a>
 
 `markdown(Title, CSS, Body) -> any()`
 
-
 <a name="module-2"></a>
 
 ### module/2 ###
 
 `module(Element, Options) -> any()`
 
-
 The layout function.
-
 
 Options to the standard layout:
 
@@ -116,14 +114,13 @@ used for exporting the documentation. See <a href="http://www.erlang.org/doc/man
 
 
 
-
 __See also:__ [//edoc/edoc:layout/2](http://www.erlang.org/doc/man/edoc.html#layout-2), [edown_doclet:layout/2](edown_doclet.md#layout-2).
+
 <a name="overview-2"></a>
 
 ### overview/2 ###
 
 `overview(E, Options) -> any()`
-
 
 <a name="package-2"></a>
 
@@ -131,11 +128,9 @@ __See also:__ [//edoc/edoc:layout/2](http://www.erlang.org/doc/man/edoc.html#lay
 
 `package(E, Options) -> any()`
 
-
 <a name="type-1"></a>
 
 ### type/1 ###
 
 `type(E) -> any()`
-
 

--- a/doc/edown_lib.md
+++ b/doc/edown_lib.md
@@ -5,29 +5,29 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 Markdown for EDoc - common support functions.
+
 Copyright (c) 2014 Ulf Wiger
 
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
 <a name="index"></a>
 
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#export-1">export/1</a></td><td></td></tr><tr><td valign="top"><a href="#get_attrval-2">get_attrval/2</a></td><td></td></tr><tr><td valign="top"><a href="#redirect_uri-1">redirect_uri/1</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#get_attrval-2">get_attrval/2</a></td><td></td></tr><tr><td valign="top"><a href="#redirect_uri-1">redirect_uri/1</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
 
 ## Function Details ##
 
-<a name="export-1"></a>
+<a name="export-2"></a>
 
-### export/1 ###
+### export/2 ###
 
-`export(Data) -> any()`
-
+`export(Data, Options) -> any()`
 
 <a name="get_attrval-2"></a>
 
@@ -35,11 +35,9 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 `get_attrval(Name, XmlElement) -> any()`
 
-
 <a name="redirect_uri-1"></a>
 
 ### redirect_uri/1 ###
 
 `redirect_uri(XmlElement) -> any()`
-
 

--- a/doc/edown_make.md
+++ b/doc/edown_make.md
@@ -4,7 +4,6 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 <a name="index"></a>
 
 ## Function Index ##
@@ -21,61 +20,44 @@
 
 ### from_script/1 ###
 
-
 <pre><code>
 from_script(Config::ConfigFile) -&gt; ok | {error, Reason}
 </code></pre>
 <br />
 
-
 Reads ConfigFile and calls [`edoc:application/3`](edoc.md#application-3)
-
-
 
 The ConfigFile will be read using [`file:script/1`](file.md#script-1), and should return
 `{App, Dir, Options}`, as required by [`edoc:application/3`](edoc.md#application-3).
 
-
 This function does not manage dependencies. It is simply a wrapper around
 [`edoc:application/3`](edoc.md#application-3).
+
 <a name="main-1"></a>
 
 ### main/1 ###
-
 
 <pre><code>
 main(Args::[Config]) -&gt; no_return()
 </code></pre>
 <br />
 
-
 Escript entry point for building edown (or edoc) documentation
-
-
 
 Usage: edown_make -config ConfigFile [-pa P] [-pz P]
 
-
-
 Calls [from_script(ConfigFile)](#from_script-1) and then terminates,
 with a normal or non-normal exit code, depending on the outcome.
-
-
 
 Make sure `$EDOWN/edown_make` is runnable, and in the command path, and
 that the edown BEAM files are in the Erlang path (e.g. using $ERL_LIBS).
 The `edown_make` escript also accepts `-pa P` and/or `-pz P` flags as a
 means of locating the edown byte code.
 
-
-
 Note, however, that the function `edoc_make:main/1` only expects the
 config file as an input argument, corresponding to
 
-
-
 `escript edoc_make.beam ConfigFile`
-
 
 (The reason for this is that if the beam file can be passed directly to
 the escript command, setting the path should also be doable that way).

--- a/doc/edown_xmerl.md
+++ b/doc/edown_xmerl.md
@@ -7,6 +7,7 @@
 Copyright (c) 2014 Ulf Wiger
 
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
 <a name="index"></a>
 
 ## Function Index ##
@@ -25,13 +26,11 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 `#element#(Tag, Data, Attrs, Parents, E) -> any()`
 
-
 <a name="%23root%23-4"></a>
 
 ### '#root#'/4 ###
 
 `#root#(Data, Attrs, X3, E) -> any()`
-
 
 <a name="%23text%23-1"></a>
 
@@ -39,11 +38,9 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 `#text#(Text) -> any()`
 
-
 <a name="%23xml-inheritance%23-0"></a>
 
 ### '#xml-inheritance#'/0 ###
 
 `#xml-inheritance#() -> any()`
-
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -114,7 +114,7 @@ output, since "raw" links wouldn't work for the markdown files.
 
 The next issue is that Edoc uses httpd_client to fetch the
 `edoc-info' files, which requires `inets' to be started. To
-further complicate matters, `ssl' (and thus `crypto' and
+further complicate matters, `ssl' (and thus `crypto', 'asn1' and
 `public_key') must also be started, since Github will
 redirect to https.
 

--- a/priv/scripts/check_edown.script
+++ b/priv/scripts/check_edown.script
@@ -14,6 +14,7 @@ case lists:member("doc", Args) of
     true ->
 	%% We actually only need to start inets if we have a doc path with http URIS
 	application:start(crypto),
+	application:start(asn1),
 	application:start(public_key),
 	application:start(ssl),
 	application:start(inets),

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -14,14 +14,13 @@
 %% limitations under the License.
 %%==============================================================================
 %% @author Ulf Wiger <ulf@wiger.net>
-%% @copyright 2014 Ulf Wiger
+%% @copyright 2014-2015 Ulf Wiger
 %% @end
 %% =============================================================================
 %% Modified 2012 by Beads Land-Trujillo:  get_git_branch/0, redirect_href/3
 %% =============================================================================
 
 %% @doc EDoc Doclet module for producing Markdown.
-
 
 -module(edown_doclet).
 
@@ -35,21 +34,17 @@
 -define(DEFAULT_FILE_SUFFIX, ".md").
 -define(INDEX_FILE, "README.md").
 -define(OVERVIEW_FILE, "overview.edoc").
--define(PACKAGE_SUMMARY, "package-summary.md").
 -define(OVERVIEW_SUMMARY, "overview-summary.md").
--define(PACKAGES_FRAME, "packages-frame.md").
--define(MODULES_FRAME, "modules-frame.md").
 -define(STYLESHEET, "stylesheet.css").
 -define(IMAGE, "erlang.png").
 -define(NL, "\n").
 
 -include_lib("xmerl/include/xmerl.hrl").
 
-%% Sources is the list of inputs in the order they were found.  Packages
-%% and Modules are sorted lists of atoms without duplicates. (They
+%% Sources is the list of inputs in the order they were found.
+%% Modules are sorted lists of atoms without duplicates. (They
 %% usually include the data from the edoc-info file in the target
-%% directory, if it exists.) Note that the "empty package" is never
-%% included in Packages!
+%% directory, if it exists.)
 
 %% @spec (Command::doclet_gen() | doclet_toc(), edoc_context()) -> ok
 %% @doc Main doclet entry point.
@@ -106,21 +101,14 @@
 %% INHERIT-OPTIONS: stylesheet/1
 
 run(#doclet_gen{}=Cmd, Ctxt) ->
-    %% dbg:tracer(),
-    %% dbg:tpl(?MODULE,x),
-    %% dbg:tpl(edown_layout,x),
-    %% dbg:tpl(edown_xmerl, x),
-    %% dbg:p(all,[c]),
     gen(Cmd#doclet_gen.sources,
 	Cmd#doclet_gen.app,
-	Cmd#doclet_gen.packages,
-	Cmd#doclet_gen.modules,
-	Cmd#doclet_gen.filemap,
+	modules(Cmd),
 	Ctxt);
 run(#doclet_toc{}=Cmd, Ctxt) ->
     toc(Cmd#doclet_toc.paths, Ctxt).
 
-gen(Sources, App, Packages, Modules, FileMap, Ctxt) ->
+gen(Sources, App, Modules, Ctxt) ->
     Dir = Ctxt#context.dir,
     Env = Ctxt#context.env,
     Options0 = Ctxt#context.opts,
@@ -131,16 +119,10 @@ gen(Sources, App, Packages, Modules, FileMap, Ctxt) ->
     Title = title(App, Options),
     %% CSS = stylesheet(Options),
     {Modules1, Error} = sources(Sources, Dir, Modules, Env, Options),
-    packages(Packages, Dir, FileMap, Env, Options),
-    Overview = overview(Dir, Title, Env, Options),
-    Data =
-	Overview
-	 ++ lists:concat([packages_frame(Packages) || Packages =/= []])
-	 ++ lists:concat([modules_frame(Modules1) || Modules1 =/= []]),
-
-    Text = xmerl:export_simple_content(Data, edown_xmerl),
-    write_file(Text, Dir, right_suffix(?INDEX_FILE, Options), '', ''),
-    edoc_lib:write_info_file(App, Packages, Modules1, Dir),
+    Data = overview(Dir, Title, Env, Options),
+    Text = edown_lib:export(Data, Options),
+    write_file(Text, Dir, right_suffix(?INDEX_FILE, Options)),
+    write_info_file(App, Modules1, Dir),
     copy_stylesheet(Dir, Options),
     copy_image(Dir, Options),
     make_top_level_README(Data, Options),
@@ -171,12 +153,11 @@ make_top_level_README(Data, Options) ->
             Dir = filename:dirname(Path),
             Filename = filename:basename(Path),
 	    make_top_level_README(Data, Dir, Filename, BaseHRef,
-                                  get_git_branch(), target(Options));
+                                  get_git_branch(), Options);
 	{Path, BaseHRef, Branch} ->
             Dir = filename:dirname(Path),
             Filename = filename:basename(Path),
-	    make_top_level_README(Data, Dir, Filename, BaseHRef, Branch,
-                                  target(Options))
+	    make_top_level_README(Data, Dir, Filename, BaseHRef, Branch, Options)
     end.
 
 target(Options) ->
@@ -186,7 +167,8 @@ target(Options) ->
 %%     Branch = get_git_branch(),
 %%     make_top_level_README(Data, Dir, F, BaseHRef, Branch).
 
-make_top_level_README(Data, Dir, F, BaseHRef, Branch, Target) ->
+make_top_level_README(Data, Dir, F, BaseHRef, Branch, Options) ->
+    Target = target(Options),
     Exp = [xmerl_lib:expand_element(D) || D <- Data],
     New = [xmerl_lib:mapxml(
 	     fun(#xmlElement{name = a,
@@ -200,7 +182,7 @@ make_top_level_README(Data, Dir, F, BaseHRef, Branch, Target) ->
 		(Other) ->
 		     Other
 	     end, Exp1) || Exp1 <- Exp],
-    Text = xmerl:export_simple_content(New, edown_xmerl),
+    Text = edown_lib:export(New, Options),
     write_file(Text, Dir, F).
 
 redirect_href(Attrs, Branch, BaseHRef, Target) ->
@@ -295,19 +277,24 @@ sources(Sources, Dir, Modules, Env, Options) ->
 %% set if it was successful. Errors are just flagged at this stage,
 %% allowing all source files to be processed even if some of them fail.
 
-source({M, P, Name, Path}, Dir, Suffix, Env, Set, Private, Hidden,
+source({M, _, Name, Path}, Dir, Suffix, Env, Set, Private, Hidden,
+       Error, Options) ->
+    %% Old style, remove package reference
+    source({M, Name, Path}, Dir, Suffix, Env, Set, Private, Hidden,
+	   Error, Options);
+source({M, Name, Path}, Dir, Suffix, Env, Set, Private, Hidden,
        Error, Options) ->
     File = filename:join(Path, Name),
     Enc = guess_encoding(File),
     case catch {ok, edoc:get_doc(File, Env, Options)} of
 	{ok, {Module, Doc}} ->
-	    check_name(Module, M, P, File),
+	    check_name(Module, M, File),
 	    case ((not is_private(Doc)) orelse Private)
 		andalso ((not is_hidden(Doc)) orelse Hidden) of
 		true ->
 		    Text = edoc:layout(Doc, Options),
-		    Name1 = packages_last(M) ++ Suffix,
-		    write_file(Text, Dir, Name1, Name, P, Enc),
+		    Name1 = atom_to_list(M) ++ Suffix,
+		    write_file(Text, Dir, Name1, Name, Enc),
 		    {sets:add_element(Module, Set), Error};
 		false ->
 		    {Set, Error}
@@ -327,22 +314,27 @@ guess_encoding(File) ->
     end.
 
 write_file(Text, Dir, F) ->
-    write_file(Text, Dir, F, F, '', auto).
+    write_file(Text, Dir, F, F, auto).
 
-write_file(Text, Dir, Name, P) ->
-    write_file(Text, Dir, Name, Name, P, auto).
-
-write_file(Text, Dir, LastName, Name, P) ->
-    write_file(Text, Dir, LastName, Name, P, auto).
-
-write_file(Text, Dir, LastName, Name, P, Enc) ->
+write_file(Text, Dir, LastName, Name, Enc) ->
     %% edoc_lib:write_file/5 (with encoding support) was added in OTP R16B
+    %% -- and removed in 18.0; we reuse the check to detect 18, since we don't
+    %% -- care about pre-R16
     case lists:member({write_file,5}, edoc_lib:module_info(exports)) of
         true ->
-            edoc_lib:write_file(Text, Dir, LastName, P,
+            edoc_lib:write_file(Text, Dir, LastName, '',
                                 [{encoding, encoding(Enc, Name)}]);
         false ->
-            edoc_lib:write_file(Text, Dir, LastName, P)
+            edoc_lib:write_file(Text, Dir, LastName,
+				[{encoding, encoding(Enc, Name)}])
+    end.
+
+write_info_file(App, Modules, Dir) ->
+    case erlang:function_exported(edoc_lib, write_info_file, 4) of
+	true ->
+	    edoc_lib:write_info_file(App, [], Modules, Dir);
+	false ->
+	    edoc_lib:write_info_file(App, Modules, Dir)
     end.
 
 encoding(auto, Name) ->
@@ -351,25 +343,9 @@ encoding(Enc, _) ->
     Enc.
 
 
-check_name(M, M0, P0, File) ->
-    case erlang:function_exported(packages, strip_last, 1) of
-	true ->
-	    check_name_(M, M0, P0, File);
-	false ->
-	    ok
-    end.
-
-%% If running pre-R16B OTP, where packages are still "supported".
-packages_last(M) ->
-    case erlang:function_exported(packages, last, 1) of
-	true  -> packages:last(M);
-	false -> atom_to_list(M)
-    end.
-
-check_name_(M, M0, P0, File) ->
-    P = list_to_atom(packages:strip_last(M)),
-    N = packages:last(M),
-    N0 = packages:last(M0),
+check_name(M, M0, File) ->
+    N = M,
+    N0 = M0,
     case N of
 	[$? | _] ->
 	    %% A module name of the form '?...' is assumed to be caused
@@ -383,83 +359,7 @@ check_name_(M, M0, P0, File) ->
 	       true ->
 		    ok
 	    end
-    end,
-    if P =/= P0 ->
-	    warning("file '~s' belongs to package '~s', not '~s'.",
-		    [File, P, P0]);
-       true ->
-	    ok
     end.
-
-
-%% Generating the summary files for packages.
-
-%% INHERIT-OPTIONS: read_file/4
-%% INHERIT-OPTIONS: edoc_lib:run_layout/2
-
-packages(Packages, Dir, FileMap, Env, Options) ->
-    lists:foreach(fun (P) ->
-			  package(P, Dir, FileMap, Env, Options)
-		  end,
-		  Packages).
-
-package(P, Dir, FileMap, Env, Opts) ->
-    Tags = case FileMap(P) of
-	       "" ->
-		   [];
-	       File ->
-		   read_file(File, package, Env, Opts)
-	   end,
-    Data = edoc_data:package(P, Tags, Env, Opts),
-    F = fun (M) ->
-		M:package(Data, Opts)
-	end,
-    Text = edoc_lib:run_layout(F, Opts),
-    write_file(Text, Dir, ?PACKAGE_SUMMARY, P).
-
-
-
-packages_frame(Ps) ->
-    [{h2, [{class, "indextitle"}], ["Packages"]},
-     {table, [{width, "100%"}, {border, 0},
-	      {summary, "list of packages"}],
-      lists:concat(
-	[[{tr, [{td, [], [{a, [{href, package_ref(P)},
-			       {class, "package"}],
-			   [atom_to_list(P)]}]}]}]
-	 || P <- Ps])}].
-
-
-modules_frame(Ms) ->
-    [{h2, [{class, "indextitle"}], ["Modules"]},
-     {table, [{width, "100%"}, {border, 0},
-	      {summary, "list of modules"}],
-      lists:concat(
-	[[?NL,
-	  {tr, [{td, [],
-		 [{a, [{href, module_ref(M)},
-		       {class, "module"}],
-		   [atom_to_list(M)]}]}]}]
-	 || M <- Ms])}].
-
-module_ref(M) ->
-    edoc_refs:relative_package_path(M, '') ++ ?DEFAULT_FILE_SUFFIX.
-
-package_ref(P) ->
-    edoc_lib:join_uri(edoc_refs:relative_package_path(P, ''),
-		      ?PACKAGE_SUMMARY).
-
-
-%% xhtml(Title, CSS, Content) ->
-%%     xhtml_1(Title, CSS, {body, [{bgcolor, "white"}], Content}).
-
-%% xhtml_1(Title, CSS, Body) ->
-%%     {html, [?NL,
-%% 	    {head, [?NL, {title, [Title]}, ?NL] ++ CSS},
-%% 	    ?NL,
-%% 	    Body,
-%% 	    ?NL]
-%%     }.
 
 %% NEW-OPTIONS: overview
 %% INHERIT-OPTIONS: read_file/4
@@ -476,8 +376,6 @@ overview(Dir, Title, Env, Opts) ->
 		M:overview(Data, Opts)
 	end,
     _Markdown = edoc_lib:run_layout(F, Opts).
-    %% edoc_lib:write_file(Text, Dir, ?OVERVIEW_SUMMARY).
-
 
 copy_image(Dir, Options) ->
     case proplists:get_value(image, Options) of
@@ -599,3 +497,8 @@ toc(_Paths, _Ctxt) ->
     %% Dir = Ctxt#context.dir,
     %% Env = Ctxt#context.env,
     %% app_index_file(Paths, Dir, Env, Opts).
+
+modules({doclet_gen,_,_,_,Ms,_}) ->  % pre-18
+    Ms;
+modules({doclet_gen,_,_,Ms}) ->  % since 18
+    Ms.

--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -90,9 +90,7 @@
 
 module(Element, Options) ->
     XML = layout_module(Element, init_opts(Element, Options)),
-    Export = proplists:get_value(xml_export, Options,
-				 ?DEFAULT_XML_EXPORT),
-    xmerl:export_simple(XML, Export, []).
+    edown_lib:export(XML, Options).
 
 % Put layout options in a data structure for easier access.
 
@@ -185,9 +183,7 @@ layout_module(#xmlElement{name = module, content = Es}=E, Opts) ->
     Body = ([]   % navigation("top")
             ++ [{h1, Title}]
 	    ++ doc_index(FullDesc, Functions, Types)
-	    ++ [{p,[]}]
-	    ++ ShortDesc
-	    ++ [{p,[]}]
+	    ++ [{p, ShortDesc}]
 	    ++ copyright(Es)
 	    ++ deprecated(Es, "module")
 	    ++ version(Es)
@@ -219,8 +215,7 @@ layout_module(#xmlElement{name = module, content = Es}=E, Opts) ->
     %% 	    io:fwrite("not edown_doclet (~p)~n", [Name])
     %% end,
     %% xhtml(Title, stylesheet(Opts), Body).
-    Res = to_simple(markdown(Title, stylesheet(Opts), Body)),
-    Res.
+    to_simple(markdown(Title, stylesheet(Opts), Body)).
 
 %% This function is a workaround for a bug in xmerl_lib:expand_content/1 that
 %% causes it to lose track of the parents if #xmlElement{} records are
@@ -911,8 +906,8 @@ t_type([E = #xmlElement{name = abstype, content = Es}]) ->
     t_abstype(E, Es);
 t_type([#xmlElement{name = union, content = Es}]) ->
     t_union(Es);
-t_type([K, V]) ->
-    t_map_field([K, V]).
+t_type([#xmlElement{name = type} = K, #xmlElement{name = type} = V]) ->
+    t_map_field([K,V]).
 
 t_var(E) ->
     [get_attrval(name, E)].
@@ -1068,8 +1063,7 @@ type(E) ->
 
 type(E, Ds) ->
     Opts = [],
-    xmerl:export_simple_content(t_utype_elem(E) ++ local_defs(Ds, Opts),
-                                ?HTML_EXPORT).
+    edown_lib:export(t_utype_elem(E) ++ local_defs(Ds, Opts), Opts).
 
 package(E=#xmlElement{name = package, content = Es}, Options) ->
     Opts = init_opts(E, Options),
@@ -1091,7 +1085,7 @@ package(E=#xmlElement{name = package, content = Es}, Options) ->
 	    ++ FullDesc),
     %% XML = xhtml(Title, stylesheet(Opts), Body),
     XML = markdown(Title, stylesheet(Opts), Body),
-    xmerl:export_simple_content(XML, ?HTML_EXPORT).
+    edown_lib:export(XML, Options).
 
 overview(E=#xmlElement{name = overview, content = Es}, Options) ->
     Opts = init_opts(E, Options),
@@ -1273,9 +1267,10 @@ ot_name([E]) ->
 
 get_first_sentence([#xmlElement{name = p, content = Es} | Tail]) ->
     %% Descend into initial paragraph.
+    Tail1 = drop_empty_lines(Tail),
     {First, Rest} = get_first_sentence_1(Es),
     {First,
-     [#xmlElement{name = p, content = Rest} || Rest =/= []] ++ Tail};
+     [#xmlElement{name = p, content = Rest} || Rest =/= []] ++ Tail1};
 get_first_sentence(Es) ->
     get_first_sentence_1(Es).
 
@@ -1295,7 +1290,8 @@ get_first_sentence_1([E = #xmlText{value = Txt} | Es], Acc) ->
 	     if Rest == [] ->
 		     Es;
 		true ->
-		     [#xmlText{value=Rest} | Es]
+		     [#xmlText{value=trim_leading_lines(
+				       normalize_text(Rest))} | Es]
 	     end};
 	none ->
 	    get_first_sentence_1(Es, [E | Acc])
@@ -1303,8 +1299,10 @@ get_first_sentence_1([E = #xmlText{value = Txt} | Es], Acc) ->
 get_first_sentence_1([E | Es], Acc) ->
     % Skip non-text segments - don't descend further
     get_first_sentence_1(Es, [E | Acc]);
+get_first_sentence_1([], []) ->
+    {[], []};
 get_first_sentence_1([], Acc) ->
-    {lists:reverse(Acc), []}.
+    {{p, lists:reverse(Acc)}, []}.
 
 end_of_sentence(Cs, Last) ->
     end_of_sentence(Cs, Last, []).
@@ -1347,3 +1345,21 @@ make_relative_uri(Path) -> Path.
 -spec drop_common_prefix(List1::list(), List2::list()) -> {List1Rest::list(), List2Rest::list()}.
 drop_common_prefix([C | List1], [C | List2]) -> drop_common_prefix(List1, List2);
 drop_common_prefix(List1, List2)             -> {List1, List2}.
+
+drop_empty_lines([#xmlText{value = Txt}=H|T]) ->
+    case trim_leading_lines(normalize_text(Txt)) of
+	[] ->
+	    drop_empty_lines(T);
+	Rest ->
+	    [H#xmlText{value = Rest}|T]
+    end;
+drop_empty_lines([H|T]) when is_list(H) ->
+    drop_empty_lines(H ++ T);
+drop_empty_lines(L) ->
+    L.
+
+trim_leading_lines([H|T]) when H==$\n; H==$\t; H==$\s ->
+    trim_leading_lines(T);
+trim_leading_lines(Str) ->
+    Str.
+

--- a/src/edown_lib.erl
+++ b/src/edown_lib.erl
@@ -23,14 +23,18 @@
 
 -module(edown_lib).
 
--export([export/1, redirect_uri/1, get_attrval/2]).
+-export([export/2, redirect_uri/1, get_attrval/2]).
 
 -include_lib("xmerl/include/xmerl.hrl").
 
+-define(HTML_EXPORT, edown_xmerl).
+-define(DEFAULT_XML_EXPORT, ?HTML_EXPORT).
 
-export(Data) ->
-    xmerl:export_simple_content(Data, edown_xmerl).
+export(Data, Options) ->
+    xmerl:export_simple(Data, export_module(Options)).
 
+export_module(Options) ->
+    proplists:get_value(xml_export, Options, ?DEFAULT_XML_EXPORT).
 
 redirect_uri(#xmlElement{} = E) ->
     redirect_uri(get_attrval(href, E), get_attrval(name, E), E);

--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -50,21 +50,23 @@ to_string(S) ->
     unicode:characters_to_list([S]).
 
 strip(Str) -> lstrip(rstrip(Str)).
-lstrip(Str) -> re:replace(Str,"^\\s","", [unicode]).
-rstrip(Str) -> re:replace(Str, "\\s\$", "", [unicode]).
+lstrip(Str) -> re:replace(Str,"^\\s","", [unicode,{return, list}]).
+rstrip(Str) -> re:replace(Str, "\\s\$", "", [unicode, {return, list}]).
 
 % Strip double spaces at end of line -- markdown reads as hard return.
-brstrip(Str) -> re:replace(Str, "\\s+\\s\$", "", [global, multiline, unicode]).
+brstrip(Str) -> re:replace(Str, "\\s+\\s\$", "", [global, multiline, unicode,
+						  {return, list}]).
 
 %% The '#root#' tag is called when the entire structure has been
 %% exported. It does not appear in the structure itself.
 
 '#root#'(Data, Attrs, [], _E) ->
+    Data1 = replace_edown_p(Data),
     case find_attribute(header, Attrs) of
 	{value, Hdr} ->
-	    [lists:flatten(io_lib:fwrite("HEADER: ~p~n", [Hdr])), Data];
+	    [lists:flatten(io_lib:fwrite("HEADER: ~p~n", [Hdr])), Data1];
 	false ->
-	    Data
+	    Data1
     end.
 
 %% Note that SGML does not have the <Tag/> empty-element form.
@@ -195,7 +197,7 @@ md_elem(Tag, Data, Attrs, Parents, E) ->
 	'div' -> Data;
 	ul    -> Data;
 	ol    -> Data;
-	p     -> ["\n", Data, "\n"];
+	p     -> ["<edown_p>", Data, "<edown_p>"];  % no need to use closing tag
 	b     -> ["__", no_nl(Data), "__"];
 	em    -> ["_", no_nl(Data), "_"];
 	i     -> ["_", no_nl(Data), "_"];
@@ -262,6 +264,22 @@ needs_html(T, _Attrs) ->
 no_nl(S) ->
     string:strip([C || C <- to_string(S),
 		       C =/= $\n], both).
+
+replace_edown_p(Data) ->
+    Data1 = binary_to_list(iolist_to_binary(Data)),
+    replace_edown_p(Data1, []).
+
+replace_edown_p("<edown_p>" ++ Data, Acc) ->
+    case lstrip(Data) of
+	"<edown_p>" ++ _ = Data1 ->
+	    replace_edown_p(Data1, Acc);
+	Data1 ->
+	    replace_edown_p(Data1, "\n\n" ++ lstrip(Acc))
+    end;
+replace_edown_p([H|T], Acc) ->
+    replace_edown_p(T, [H|Acc]);
+replace_edown_p([], Acc) ->
+    lists:reverse(Acc).
 
 %% attr(#xmlAttribute{name = N, value = V}) ->
 %%     "(" ++ atom_to_list(N) ++ "=" ++ [a_val(V)] ++ ")".


### PR DESCRIPTION
#### 変更内容

uwiger/edownのmasterをmergeしました。
#### 主な目的

Erlang/OTP18対応です。
#### その他
- 変更後のソースとuwiger/masterとの差分は元々dwango/edownで追加されている差分のみです
- Erlang/OTP17でも動作し同じドキュメントが生成されることは軽くだけ確認してあります
  - 特定のリポジトリ（dwango/moyo）でのみ確認
