### PR TITLE
fix iolist_to_binary/1 and binary_to_list/1 to characters_to_list/1

### DIFF
--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -266,7 +266,8 @@ no_nl(S) ->
 		       C =/= $\n], both).
 
 replace_edown_p(Data) ->
-    Data1 = binary_to_list(iolist_to_binary(Data)),
+    %%Data1 = binary_to_list(iolist_to_binary(Data)),
+    Data1 = unicode:characters_to_list([Data]),
     replace_edown_p(Data1, []).
 
 replace_edown_p("<edown_p>" ++ Data, Acc) ->


### PR DESCRIPTION
修正が足りなかった部分があったため、再度PRを送ります。
#### 修正内容
- `binary_to_list(iolist_to_binary(Data))` になっていた部分を `characters_to_list([Data])` に修正
#### 主な目的
- `char()` (Unicode)対応
#### その他

リポジトリ内で他に `iolist_to_binary/1` が使われていないかは確かめました。
もう一ヶ所で使われている部分は既に置き換えられていました。（同edown_xmerl.erl 50行目）
